### PR TITLE
remove target=“_blank” in docs index

### DIFF
--- a/buildSrc/src/main/resources/index.html
+++ b/buildSrc/src/main/resources/index.html
@@ -380,7 +380,7 @@
                         <li id="menu-item-3838" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3838"><a href="https://micronaut.io/meeting-minutes/" class="dropdown-item">Meeting Minutes</a></li>
                     </ul>
                     </li>
-                    <li id="menu-item-2884" class="action menu-item menu-item-type-custom menu-item-object-custom menu-item-2884 nav-item"><a target="_blank" rel="noopener" href="https://micronaut.io/launch/" class="nav-link">Launch</a></li>
+                    <li id="menu-item-2884" class="action menu-item menu-item-type-custom menu-item-object-custom menu-item-2884 nav-item"><a  href="https://micronaut.io/launch/" class="nav-link">Launch</a></li>
 
                 </ul>
 
@@ -414,11 +414,11 @@
                     <ul class="list list_compact">
 
                         <li>
-                            <a href="https://docs.micronaut.io/latest/guide" target="_blank">User Guide</a>
+                            <a href="https://docs.micronaut.io/latest/guide" >User Guide</a>
                         </li>
 
                         <li>
-                            <a href="https://docs.micronaut.io/latest/api/" target="_blank">API Reference</a>
+                            <a href="https://docs.micronaut.io/latest/api/" >API Reference</a>
                         </li>
 
                     </ul>
@@ -515,7 +515,7 @@
                                 </a>
                             </li>
                             <li id="menu-item-2886" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-2886">
-                                <a target="_blank" rel="noopener" href="https://twitter.com/micronautfw">
+                                <a  href="https://twitter.com/micronautfw">
                                     <i class="fab fa-twitter">
                                         <span class="sr-only">Twitter</span>
                                     </i>
@@ -535,14 +535,14 @@
                                 </a>
                             </li>
                             <li id="menu-item-2889" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-2889">
-                                <a target="_blank" rel="noopener" href="https://github.com/micronaut-projects/">
+                                <a  href="https://github.com/micronaut-projects/">
                                     <i class="fab fa-github">
                                         <span class="sr-only">GitHub</span>
                                     </i>
                                 </a>
                             </li>
                             <li id="menu-item-2890" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-2890">
-                                <a target="_blank" rel="noopener" href="https://www.youtube.com/@MicronautFramework">
+                                <a  href="https://www.youtube.com/@MicronautFramework">
                                     <i class="fab fa-youtube">
                                         <span class="sr-only">YouTube</span>
                                     </i>

--- a/buildSrc/src/main/resources/repository.html
+++ b/buildSrc/src/main/resources/repository.html
@@ -1,6 +1,6 @@
 <li>
     <h4 class="title title_small">
-        <a href="https://micronaut-projects.github.io/@slug@/@version@" target="_blank">@title@</a>
+        <a href="https://micronaut-projects.github.io/@slug@/@version@" >@title@</a>
     </h4>
     @description@
 </li>


### PR DESCRIPTION
Let users have the freedom to choose how they want to open links. Our audience is tech-savvy. If they want to open a link in a new tab or window, they know how to do it.

Moreover, it is really convinient to remove target=_blank to use Micronaut documentation as a [Safari Web App](https://support.apple.com/en-us/104996)