### PR TITLE
Add Micronaut Jakarta EL to the languages category

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -215,6 +215,11 @@ categories:
         slug: 'micronaut-graal-languages'
         title: 'Micronaut Graal Languages'
         description: 'Integrate Graal based dynamic languages with Micronaut Framework'        
+      jakarta-el:
+        snapshot: true
+        slug: 'micronaut-jakarta-el'
+        title: 'Micronaut Jakarta EL'
+        description: 'A Jakarta Expression Language implementation whose expressions and resolvers are generated at compilation time'
   messaging:
     title: 'Messaging'
     image: 'https://micronaut.io/wp-content/uploads/2020/11/Messaging.svg'


### PR DESCRIPTION
Adds `micronaut-jakarta-el` to the Languages category — a Jakarta Expression Language 6.0 implementation whose expressions and resolvers are generated at compilation time.

Part of the [New Module Checklist](https://github.com/micronaut-projects/micronaut-core/wiki/New-Module-Checklist).

The module has no stable release yet, so the entry carries `snapshot: true` and points at the snapshot guide, like `micronaut-mcp` and `micronaut-projectgen`. Drop the flag once `v1.0.0` is out.

Note: this should merge only after the module's first push publishes its `gh-pages` docs, otherwise the link 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
